### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ VSCode LSP MCP is a Visual Studio Code extension that exposes Language Server Pr
 ![vscode-ext](./docAssets/vsc-ext.webp)
 ![demo](./docAssets/demo.webp)
 
+<a href="https://glama.ai/mcp/servers/@beixiyo/vsc-lsp-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@beixiyo/vsc-lsp-mcp/badge" alt="VSCode LSP Server MCP server" />
+</a>
+
 ### 🌟 Why This Extension?
 
 Large language models like Claude and Cursor struggle to understand your codebase accurately because:


### PR DESCRIPTION
This PR adds a badge for the [VSCode LSP MCP Server](https://glama.ai/mcp/servers/@beixiyo/vsc-lsp-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@beixiyo/vsc-lsp-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@beixiyo/vsc-lsp-mcp/badge" alt="VSCode LSP Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.