### PR TITLE
feat: add get_class_file_contents tool for decompiled Java class source code

### DIFF
--- a/src/lsp/classFileContents.ts
+++ b/src/lsp/classFileContents.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode'
+import { logger } from '../utils/logger'
+
+/**
+ * 通过 jdt:// URI 获取反编译的 Java 类文件源码
+ *
+ * @param uri jdt:// 格式的 URI
+ * @returns 反编译后的源码文本
+ */
+export async function getClassFileContents(uri: string): Promise<string> {
+  try {
+    if (!uri.startsWith('jdt://')) {
+      throw new Error(`无效的 URI 格式，需要 jdt:// 开头: ${uri}`)
+    }
+
+    logger.info(`获取类文件内容: ${uri}`)
+
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(uri))
+    return doc.getText()
+  }
+  catch (error) {
+    logger.error('获取类文件内容失败', error)
+    throw error
+  }
+}

--- a/src/lsp/index.ts
+++ b/src/lsp/index.ts
@@ -1,3 +1,4 @@
+export * from './classFileContents'
 export * from './completion'
 export * from './definition'
 export * from './hover'

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import {
+  getClassFileContents,
   getCompletions,
   getDefinition,
   getHover,
@@ -79,6 +80,21 @@ export function addLspTools(server: McpServer) {
     async ({ uri, line, character }) => {
       const result = await getReferences(uri, line, character)
       return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    },
+  )
+
+  server.registerTool(
+    'get_class_file_contents',
+    {
+      title: 'Get Class File Contents',
+      description: 'Get decompiled source code of a Java class file via jdt:// URI. Use this to retrieve the source of library/dependency classes that jdtls references. The jdt:// URI is typically obtained from definition or hover results.',
+      inputSchema: {
+        uri: z.string().describe('The jdt:// URI of the class file. Typically obtained from go-to-definition results pointing to dependency classes.'),
+      },
+    },
+    async ({ uri }) => {
+      const result = await getClassFileContents(uri)
+      return { content: [{ type: 'text', text: result }] }
     },
   )
 


### PR DESCRIPTION
## 新增 `get_class_file_contents` 工具：通过 jdt:// URI 获取反编译 Java 类源码

### 动机

在使用 AI Agent IDE（如 Kiro）与 jdtls 交互时，`get_definition` 经常会返回 `jdt://` 协议的 URI，指向依赖库中的类文件。但目前没有工具能根据这个 URI 获取对应的反编译源码，导致 Agent 无法进一步阅读和理解依赖类的实现细节。

### 改动内容

新增 `get_class_file_contents` MCP 工具，接收 `jdt://` URI，通过 VS Code 的 `TextDocumentContentProvider` 机制调用 jdtls 返回反编译后的 Java 源码。

- 新增 `src/lsp/classFileContents.ts`
- 在 `src/mcp/tools.ts` 中注册该工具
- 在 `src/lsp/index.ts` 中导出

### 使用场景

典型工作流：
1. Agent 调用 `get_definition` 跳转到某个符号的定义
2. 返回结果中包含 `jdt://` URI（说明定义在外部依赖中）
3. Agent 调用 `get_class_file_contents` 传入该 URI，获取反编译源码进行分析
